### PR TITLE
Focus 3 - API Testing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["cucumberopen.cucumber-official"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cucumber.glue": ["cypress/e2e/**/step_definitions/**/*.{js,ts}"],
+  "cucumber.features": ["cypress/e2e/**/*.feature"]
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         nonGlobalStepDefinitions: true,
         stepDefinitions: [
           "cypress/e2e/saucedemo/step_definitions/**/*.{js,ts}",
+          "cypress/e2e/jsonplaceholder/step_definitions/**/*.{js,ts}",
         ],
       },
     },
@@ -27,7 +28,7 @@ export default defineConfig({
         "file:preprocessor",
         createBundler({
           plugins: [createEsbuildPlugin(config)],
-        })
+        }),
       );
 
       // Return the updated config

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,4 +1,4 @@
 {
-  "username": "change_to_your_username",
-  "password": "change_to_your_password"
+  "username": "standard_user",
+  "password": "secret_sauce"
 }

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,4 +1,5 @@
 {
   "username": "change_to_your_actual_username",
-  "password": "change_to_your_password"
+  "password": "change_to_your_password",
+  "apiBaseUrl": "https://jsonplaceholder.typicode.com"
 }

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,4 +1,4 @@
 {
-  "username": "standard_user",
-  "password": "secret_sauce"
+  "username": "change_to_your_actual_username",
+  "password": "change_to_your_password"
 }

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -14,11 +14,11 @@ Scenario: Fetch filtered data (GET)
     Then I should receive 10 posts
     And every post should belong to userId 1
 
-# Scenario: Replace a post (PUT)
-#     When I replace the target post with the replacement data
-#     Then the response status should be 200
-#     And the post title should match the replacement data
-#     And the post body should match the replacement data
+Scenario: Replace a post (PUT)
+    When I replace the target post with replacement data
+    Then the response status should be 200
+    And the post title should match the replacement data
+    And the post body should match the replacement data
 
 # Scenario: Partially update a post (PATCH)
 #     When I update only the title of the target post

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -9,6 +9,11 @@ Scenario: Create a new post (POST)
     Then the response status should be 201
     And the ID in the response should be 101
 
+Scenario: Fetch all posts (GET)
+    When I fetch all posts
+    Then the response status should be 200
+    And I should receive a list of posts matching the expected total count
+
 Scenario: Fetch a post by ID (GET)
     When I fetch the target post
     Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -1,0 +1,20 @@
+@api @posts
+Feature: Post Lifecycle Management
+  As an API consumer 
+  I want to manage blog posts via the JSONPlaceholder API
+  So that I can verify data integrity across the system
+
+  Scenario: Create, Verify, and Update a post
+    When I create a new post with title "Cross-Skilling" and body "Focus 3 API Test"
+    Then the response status should be 201
+    And the response should include a new ID
+
+    When I fetch all posts for userId 1
+    Then I should receive exactly 10 posts
+
+    When I update post 1 with title "Updated Title"
+    Then the response status should be 200
+    And the post title should be "Updated Title"
+
+    When I delete post 1
+    Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -9,23 +9,28 @@ Scenario: Create a new post (POST)
     Then the response status should be 201
     And the ID in the response should be 101
 
+Scenario: Fetch a post by ID (GET)
+    When I fetch the target post
+    Then the response status should be 200
+    And the response should match the expected post data
+
 Scenario: Fetch filtered data (GET)
-    When I fetch all posts for userId 1
-    Then I should receive 10 posts
-    And every post should belong to userId 1
+    When I fetch all posts for the target user
+    Then I should receive the expected number of posts
+    And every post should belong to the target user
 
 Scenario: Replace a post (PUT)
-    When I replace the target post with replacement data
+    When I replace the test post with replacement data
     Then the response status should be 200
     And the post title should match the replacement data
     And the post body should match the replacement data
 
- Scenario: Partially update a post (PATCH)
-    When I update only the title of the target post
+Scenario: Partially update a post (PATCH)
+    When I update the test post with patched data
     Then the response status should be 200
     And the post title should match the patched title
     And the original body should still be present in the response
 
-# Scenario: Remove a post (DELETE)
-#     When I delete the target post
-#     Then the response status should be 200
+Scenario: Remove a post (DELETE)
+    When I delete the test post
+    Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -24,6 +24,12 @@ Scenario: Fetch filtered data (GET)
     Then I should receive the expected number of posts
     And every post should belong to the target user
 
+Scenario: Fetch nested resources (GET)
+    When I fetch the target post with embedded comments
+    Then the response status should be 200
+    And every item in the response should have a post ID matching the one specified
+    And every item in the response should have a name and email
+
 Scenario: Replace a post (PUT)
     When I replace the test post with replacement data
     Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -20,11 +20,11 @@ Scenario: Replace a post (PUT)
     And the post title should match the replacement data
     And the post body should match the replacement data
 
-# Scenario: Partially update a post (PATCH)
-#     When I update only the title of the target post
-#     Then the response status should be 200
-#     And the post title should match the patched title
-#     And the original body should still be present in the response
+ Scenario: Partially update a post (PATCH)
+    When I update only the title of the target post
+    Then the response status should be 200
+    And the post title should match the patched title
+    And the original body should still be present in the response
 
 # Scenario: Remove a post (DELETE)
 #     When I delete the target post

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -1,20 +1,31 @@
 @api @posts
 Feature: Post Lifecycle Management
-  As an API consumer 
-  I want to manage blog posts via the JSONPlaceholder API
-  So that I can verify data integrity across the system
+As an API consumer
+I want to manage blog posts via the JSONPlaceholder API
+So that I can verify data integrity across the system
 
-  Scenario: Create, Verify, and Update a post
-    When I create a new post with title "Cross-Skilling" and body "Focus 3 API Test"
+Scenario: Create a new post (POST)
+    When I create a new post
     Then the response status should be 201
-    And the response should include a new ID
+#     And the response should include a new ID
 
-    When I fetch all posts for userId 1
-    Then I should receive exactly 10 posts
+# Scenario: Fetch filtered data (GET)
+#     When I fetch all posts for the specified userId
+#     Then I should receive the expected number of posts
+#     And every post should belong to that userId
 
-    When I update post 1 with title "Updated Title"
-    Then the response status should be 200
-    And the post title should be "Updated Title"
+# Scenario: Replace a post (PUT)
+#     When I replace the target post with the replacement data
+#     Then the response status should be 200
+#     And the post title should match the replacement data
+#     And the post body should match the replacement data
 
-    When I delete post 1
-    Then the response status should be 200
+# Scenario: Partially update a post (PATCH)
+#     When I update only the title of the target post
+#     Then the response status should be 200
+#     And the post title should match the patched title
+#     And the original body should still be present in the response
+
+# Scenario: Remove a post (DELETE)
+#     When I delete the target post
+#     Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -7,12 +7,12 @@ So that I can verify data integrity across the system
 Scenario: Create a new post (POST)
     When I create a new post
     Then the response status should be 201
-#     And the response should include a new ID
+    And the ID in the response should be 101
 
-# Scenario: Fetch filtered data (GET)
-#     When I fetch all posts for the specified userId
-#     Then I should receive the expected number of posts
-#     And every post should belong to that userId
+Scenario: Fetch filtered data (GET)
+    When I fetch all posts for userId 1
+    Then I should receive 10 posts
+    And every post should belong to userId 1
 
 # Scenario: Replace a post (PUT)
 #     When I replace the target post with the replacement data

--- a/cypress/e2e/jsonplaceholder/features/posts.feature
+++ b/cypress/e2e/jsonplaceholder/features/posts.feature
@@ -21,6 +21,7 @@ Scenario: Fetch a post by ID (GET)
 
 Scenario: Fetch filtered data (GET)
     When I fetch all posts for the target user
+    Then the response status should be 200
     Then I should receive the expected number of posts
     And every post should belong to the target user
 
@@ -43,5 +44,6 @@ Scenario: Partially update a post (PATCH)
     And the original body should still be present in the response
 
 Scenario: Remove a post (DELETE)
+    Given the test post is available
     When I delete the test post
     Then the response status should be 200

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -5,18 +5,14 @@
 class PostService {
   private baseUrl = "https://jsonplaceholder.typicode.com";
 
-  // TODO (Best Practice): userId is hardcoded here rather than being accepted as a parameter
-  // or sourced from the fixture. Since userId is meaningful test data, it should be passed in
-  // (e.g. createPost(title: string, body: string, userId: number)) or read from the fixture
-  // via the step definition to keep test data centralised and the method reusable.
-  createPost(title: string, body: string) {
+  createPost(title: string, body: string, userId: number) {
     return cy.request({
       method: "POST",
       url: `${this.baseUrl}/posts`,
       body: {
         title,
         body,
-        userId: 1,
+        userId,
       },
     });
   }

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -39,6 +39,20 @@ class PostService {
     });
   }
 
+  deletePost(postId: number) {
+    return cy.request({
+      method: "DELETE",
+      url: `${this.baseUrl}/posts/${postId}`,
+    });
+  }
+
+  getPostById(postId: number) {
+    return cy.request({
+      method: "GET",
+      url: `${this.baseUrl}/posts/${postId}`,
+    });
+  }
+
   getPostsByUserId(userId: number) {
     return cy.request({
       method: "GET",

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -46,6 +46,13 @@ class PostService {
     });
   }
 
+  getAllPosts() {
+    return cy.request({
+      method: "GET",
+      url: `${this.baseUrl}/posts`,
+    });
+  }
+
   getPostById(postId: number) {
     return cy.request({
       method: "GET",

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -3,7 +3,9 @@
  * This is intended to follow the Page Object Model pattern used in Focus 2
  */
 class PostService {
-  private baseUrl = "https://jsonplaceholder.typicode.com";
+  private get baseUrl(): string {
+    return Cypress.env("apiBaseUrl");
+  }
 
   createPost(title: string, body: string, userId: number) {
     return cy.request({

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -5,6 +5,10 @@
 class PostService {
   private baseUrl = "https://jsonplaceholder.typicode.com";
 
+  // TODO (Best Practice): userId is hardcoded here rather than being accepted as a parameter
+  // or sourced from the fixture. Since userId is meaningful test data, it should be passed in
+  // (e.g. createPost(title: string, body: string, userId: number)) or read from the fixture
+  // via the step definition to keep test data centralised and the method reusable.
   createPost(title: string, body: string) {
     return cy.request({
       method: "POST",
@@ -12,7 +16,17 @@ class PostService {
       body: {
         title,
         body,
-        userId: 1, // Assuming a userId for the sake of the test
+        userId: 1,
+      },
+    });
+  }
+
+  getPostsByUserId(userId: number) {
+    return cy.request({
+      method: "GET",
+      url: `${this.baseUrl}/posts`,
+      qs: {
+        userId,
       },
     });
   }

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -1,0 +1,21 @@
+/**
+ * PostService encapsulates all API interactions for the /posts resource.
+ * This is intended to follow the Page Object Model pattern used in Focus 2
+ */
+class PostService {
+  private baseUrl = "https://jsonplaceholder.typicode.com";
+
+  createPost(title: string, body: string) {
+    return cy.request({
+      method: "POST",
+      url: `${this.baseUrl}/posts`,
+      body: {
+        title,
+        body,
+        userId: 1, // Assuming a userId for the sake of the test
+      },
+    });
+  }
+}
+
+export default new PostService();

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -17,6 +17,18 @@ class PostService {
     });
   }
 
+  replacePost(postId: number, title: string, body: string, userId: number) {
+    return cy.request({
+      method: "PUT",
+      url: `${this.baseUrl}/posts/${postId}`,
+      body: {
+        title,
+        body,
+        userId,
+      },
+    });
+  }
+
   getPostsByUserId(userId: number) {
     return cy.request({
       method: "GET",

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -69,6 +69,13 @@ class PostService {
       },
     });
   }
+
+  getCommentsByPostId(postId: number) {
+    return cy.request({
+      method: "GET",
+      url: `${this.baseUrl}/posts/${postId}/comments`,
+    });
+  }
 }
 
 export default new PostService();

--- a/cypress/e2e/jsonplaceholder/services/PostService.ts
+++ b/cypress/e2e/jsonplaceholder/services/PostService.ts
@@ -29,6 +29,16 @@ class PostService {
     });
   }
 
+  patchPost(postId: number, title: string) {
+    return cy.request({
+      method: "PATCH",
+      url: `${this.baseUrl}/posts/${postId}`,
+      body: {
+        title,
+      },
+    });
+  }
+
   getPostsByUserId(userId: number) {
     return cy.request({
       method: "GET",

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -28,7 +28,7 @@ interface ExpectedPost {
 interface PostsData {
   testPostId: number;
   targetUserId: number;
-  allPostsExpectedCount: number;
+  allPostsExpectedTotalCount: number;
   expectedPost: ExpectedPost;
   newPost: NewPost;
   replacePost: ReplacePost;
@@ -61,6 +61,26 @@ Then("the ID in the response should be {int}", (expectedID: number) => {
     expect(lastResponse.body.id).to.eq(expectedID);
   });
 });
+
+When("I fetch all posts", () => {
+  PostService.getAllPosts().then((response) => {
+    cy.wrap(response).as("lastResponse");
+  });
+});
+
+Then(
+  "I should receive a list of posts matching the expected total count",
+  () => {
+    cy.get("@lastResponse").then((lastResponse: any) => {
+      cy.get("@postsData").then((postsData: any) => {
+        const { allPostsExpectedTotalCount } = postsData as PostsData;
+        expect(lastResponse.body)
+          .to.be.an("array")
+          .with.lengthOf(allPostsExpectedTotalCount);
+      });
+    });
+  },
+);
 
 When("I fetch the target post", () => {
   cy.get("@postsData").then((postsData: any) => {

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -1,13 +1,12 @@
-import { When, Then, Before } from "@badeball/cypress-cucumber-preprocessor";
+import {
+  Given,
+  When,
+  Then,
+  Before,
+} from "@badeball/cypress-cucumber-preprocessor";
 import PostService from "../services/PostService";
 
-interface NewPost {
-  title: string;
-  body: string;
-  userId: number;
-}
-
-interface ReplacePost {
+interface Post {
   title: string;
   body: string;
   userId: number;
@@ -25,14 +24,20 @@ interface ExpectedPost {
   userId: number;
 }
 
+interface CommentItem {
+  postId: number;
+  name: string;
+  email: string;
+}
+
 interface PostsData {
   testPostId: number;
   targetUserId: number;
   allPostsExpectedCount: number;
   allPostsExpectedTotalCount: number;
   expectedPost: ExpectedPost;
-  newPost: NewPost;
-  replacePost: ReplacePost;
+  newPost: Post;
+  replacePost: Post;
   patchPost: PatchPost;
 }
 
@@ -40,9 +45,16 @@ Before(() => {
   cy.fixture("posts.json").as("postsData");
 });
 
+Given("the test post is available", () => {
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId } = postsData;
+    expect(testPostId).to.exist;
+  });
+});
+
 When("I create a new post", () => {
-  cy.get("@postsData").then((postsData: any) => {
-    const { newPost } = postsData as PostsData;
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { newPost } = postsData;
     PostService.createPost(newPost.title, newPost.body, newPost.userId).then(
       (response) => {
         cy.wrap(response).as("lastResponse");
@@ -52,15 +64,17 @@ When("I create a new post", () => {
 });
 
 Then("the response status should be {int}", (statusCode: number) => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
+  cy.get<Cypress.Response<unknown>>("@lastResponse").then((lastResponse) => {
     expect(lastResponse.status).to.eq(statusCode);
   });
 });
 
 Then("the ID in the response should be {int}", (expectedID: number) => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    expect(lastResponse.body.id).to.eq(expectedID);
-  });
+  cy.get<Cypress.Response<{ id: number }>>("@lastResponse").then(
+    (lastResponse) => {
+      expect(lastResponse.body.id).to.eq(expectedID);
+    },
+  );
 });
 
 When("I fetch all posts", () => {
@@ -72,20 +86,22 @@ When("I fetch all posts", () => {
 Then(
   "I should receive a list of posts matching the expected total count",
   () => {
-    cy.get("@lastResponse").then((lastResponse: any) => {
-      cy.get("@postsData").then((postsData: any) => {
-        const { allPostsExpectedTotalCount } = postsData as PostsData;
-        expect(lastResponse.body)
-          .to.be.an("array")
-          .with.lengthOf(allPostsExpectedTotalCount);
-      });
-    });
+    cy.get<Cypress.Response<ExpectedPost[]>>("@lastResponse").then(
+      (lastResponse) => {
+        cy.get<PostsData>("@postsData").then((postsData) => {
+          const { allPostsExpectedTotalCount } = postsData;
+          expect(lastResponse.body)
+            .to.be.an("array")
+            .with.lengthOf(allPostsExpectedTotalCount);
+        });
+      },
+    );
   },
 );
 
 When("I fetch the target post", () => {
-  cy.get("@postsData").then((postsData: any) => {
-    const { testPostId } = postsData as PostsData;
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId } = postsData;
     PostService.getPostById(testPostId).then((response) => {
       cy.wrap(response).as("lastResponse");
     });
@@ -93,21 +109,23 @@ When("I fetch the target post", () => {
 });
 
 Then("the response should match the expected post data", () => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { expectedPost } = postsData as PostsData;
-      expect(lastResponse.body).to.deep.include({
-        title: expectedPost.title,
-        body: expectedPost.body,
-        userId: expectedPost.userId,
+  cy.get<Cypress.Response<ExpectedPost>>("@lastResponse").then(
+    (lastResponse) => {
+      cy.get<PostsData>("@postsData").then((postsData) => {
+        const { expectedPost } = postsData;
+        expect(lastResponse.body).to.deep.include({
+          title: expectedPost.title,
+          body: expectedPost.body,
+          userId: expectedPost.userId,
+        });
       });
-    });
-  });
+    },
+  );
 });
 
 When("I fetch all posts for the target user", () => {
-  cy.get("@postsData").then((postsData: any) => {
-    const { targetUserId } = postsData as PostsData;
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { targetUserId } = postsData;
     PostService.getPostsByUserId(targetUserId).then((response) => {
       cy.wrap(response).as("lastResponse");
     });
@@ -115,31 +133,34 @@ When("I fetch all posts for the target user", () => {
 });
 
 Then("I should receive the expected number of posts", () => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { allPostsExpectedCount } = postsData as PostsData;
-      expect(lastResponse.status).to.eq(200);
-      expect(lastResponse.body)
-        .to.be.an("array")
-        .with.lengthOf(allPostsExpectedCount);
-    });
-  });
+  cy.get<Cypress.Response<ExpectedPost[]>>("@lastResponse").then(
+    (lastResponse) => {
+      cy.get<PostsData>("@postsData").then((postsData) => {
+        const { allPostsExpectedCount } = postsData;
+        expect(lastResponse.body)
+          .to.be.an("array")
+          .with.lengthOf(allPostsExpectedCount);
+      });
+    },
+  );
 });
 
 Then("every post should belong to the target user", () => {
-  cy.get("@postsData").then((postsData: any) => {
-    cy.get("@lastResponse").then((lastResponse: any) => {
-      const { targetUserId } = postsData as PostsData;
-      lastResponse.body.forEach((post: { userId: number }) => {
-        expect(post.userId).to.eq(targetUserId);
-      });
-    });
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    cy.get<Cypress.Response<ExpectedPost[]>>("@lastResponse").then(
+      (lastResponse) => {
+        const { targetUserId } = postsData;
+        lastResponse.body.forEach((post) => {
+          expect(post.userId).to.eq(targetUserId);
+        });
+      },
+    );
   });
 });
 
 When("I fetch the target post with embedded comments", () => {
-  cy.get("@postsData").then((postsData: any) => {
-    const { testPostId } = postsData as PostsData;
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId } = postsData;
     PostService.getCommentsByPostId(testPostId).then((response) => {
       cy.wrap(response).as("lastResponse");
     });
@@ -149,34 +170,37 @@ When("I fetch the target post with embedded comments", () => {
 Then(
   "every item in the response should have a post ID matching the one specified",
   () => {
-    cy.get("@lastResponse").then((lastResponse: any) => {
-      cy.get("@postsData").then((postsData: any) => {
-        const { testPostId } = postsData as PostsData;
-        expect(lastResponse.body).to.be.an("array").with.length.greaterThan(0);
-        lastResponse.body.forEach((comment: { postId: number }) => {
-          expect(comment.postId).to.eq(testPostId);
+    cy.get<Cypress.Response<CommentItem[]>>("@lastResponse").then(
+      (lastResponse) => {
+        cy.get<PostsData>("@postsData").then((postsData) => {
+          const { testPostId } = postsData;
+          expect(lastResponse.body)
+            .to.be.an("array")
+            .with.length.greaterThan(0);
+          lastResponse.body.forEach((comment) => {
+            expect(comment.postId).to.eq(testPostId);
+          });
         });
-      });
-    });
+      },
+    );
   },
 );
 
 Then("every item in the response should have a name and email", () => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { testPostId } = postsData as PostsData;
+  cy.get<Cypress.Response<CommentItem[]>>("@lastResponse").then(
+    (lastResponse) => {
       expect(lastResponse.body).to.be.an("array").with.length.greaterThan(0);
-      lastResponse.body.forEach((comment: { name: string; email: string }) => {
+      lastResponse.body.forEach((comment) => {
         expect(comment).to.have.property("name");
         expect(comment).to.have.property("email");
       });
-    });
-  });
+    },
+  );
 });
 
-When("I replace the test post with replacement data", function () {
-  cy.get("@postsData").then((postsData: any) => {
-    const { testPostId, replacePost } = postsData as PostsData;
+When("I replace the test post with replacement data", () => {
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId, replacePost } = postsData;
     PostService.replacePost(
       testPostId,
       replacePost.title,
@@ -188,54 +212,54 @@ When("I replace the test post with replacement data", function () {
   });
 });
 
-Then("the post title should match the replacement data", function () {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { replacePost } = postsData as PostsData;
+Then("the post title should match the replacement data", () => {
+  cy.get<Cypress.Response<Post>>("@lastResponse").then((lastResponse) => {
+    cy.get<PostsData>("@postsData").then((postsData) => {
+      const { replacePost } = postsData;
       expect(lastResponse.body).to.have.property("title", replacePost.title);
     });
   });
 });
 
-Then("the post body should match the replacement data", function () {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { replacePost } = postsData as PostsData;
+Then("the post body should match the replacement data", () => {
+  cy.get<Cypress.Response<Post>>("@lastResponse").then((lastResponse) => {
+    cy.get<PostsData>("@postsData").then((postsData) => {
+      const { replacePost } = postsData;
       expect(lastResponse.body).to.have.property("body", replacePost.body);
     });
   });
 });
 
-When("I update the test post with patched data", function () {
-  cy.get("@postsData").then((postsData: any) => {
-    const { testPostId, patchPost } = postsData as PostsData;
+When("I update the test post with patched data", () => {
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId, patchPost } = postsData;
     PostService.patchPost(testPostId, patchPost.title).then((response) => {
       cy.wrap(response).as("lastResponse");
     });
   });
 });
 
-Then("the post title should match the patched title", function () {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { patchPost } = postsData as PostsData;
+Then("the post title should match the patched title", () => {
+  cy.get<Cypress.Response<PatchPost>>("@lastResponse").then((lastResponse) => {
+    cy.get<PostsData>("@postsData").then((postsData) => {
+      const { patchPost } = postsData;
       expect(lastResponse.body).to.have.property("title", patchPost.title);
     });
   });
 });
 
-Then("the original body should still be present in the response", function () {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    cy.get("@postsData").then((postsData: any) => {
-      const { patchPost } = postsData as PostsData;
+Then("the original body should still be present in the response", () => {
+  cy.get<Cypress.Response<PatchPost>>("@lastResponse").then((lastResponse) => {
+    cy.get<PostsData>("@postsData").then((postsData) => {
+      const { patchPost } = postsData;
       expect(lastResponse.body).to.have.property("body", patchPost.body);
     });
   });
 });
 
-When("I delete the test post", function () {
-  cy.get("@postsData").then((postsData: any) => {
-    const { testPostId } = postsData as PostsData;
+When("I delete the test post", () => {
+  cy.get<PostsData>("@postsData").then((postsData) => {
+    const { testPostId } = postsData;
     PostService.deletePost(testPostId).then((response) => {
       cy.wrap(response).as("lastResponse");
     });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -14,9 +14,16 @@ interface ReplacePost {
   userId: number;
 }
 
+interface PatchPost {
+  postId: number;
+  title: string;
+  body: string;
+}
+
 interface PostsData {
   newPost: NewPost;
   replacePost: ReplacePost;
+  patchPost: PatchPost;
 }
 
 Before(() => {
@@ -95,6 +102,35 @@ Then("the post body should match the replacement data", function () {
     cy.get("@postsData").then((postsData: any) => {
       const { replacePost } = postsData as PostsData;
       expect(lastResponse.body).to.have.property("body", replacePost.body);
+    });
+  });
+});
+
+When("I update only the title of the target post", function () {
+  cy.get("@postsData").then((postsData: any) => {
+    const { patchPost } = postsData as PostsData;
+    PostService.patchPost(patchPost.postId, patchPost.title).then(
+      (response) => {
+        cy.wrap(response).as("lastResponse");
+      },
+    );
+  });
+});
+
+Then("the post title should match the patched title", function () {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { patchPost } = postsData as PostsData;
+      expect(lastResponse.body).to.have.property("title", patchPost.title);
+    });
+  });
+});
+
+Then("the original body should still be present in the response", function () {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { patchPost } = postsData as PostsData;
+      expect(lastResponse.body).to.have.property("body", patchPost.body);
     });
   });
 });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -1,6 +1,9 @@
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 import PostService from "../services/PostService";
 
+// TODO (Best Practice): Storing response in a module-level variable shares state across scenarios.
+// Consider using a Cypress alias instead (e.g. cy.wrap(response).as('lastResponse') and cy.get('@lastResponse'))
+// so that response state is naturally scoped to each individual scenario.
 let lastResponse: Cypress.Response<any>;
 
 interface NewPost {
@@ -29,4 +32,30 @@ When("I create a new post", () => {
 
 Then("the response status should be {int}", (statusCode: number) => {
   expect(lastResponse.status).to.eq(statusCode);
+});
+
+Then("the ID in the response should be {int}", (expectedID: number) => {
+  expect(lastResponse.body).to.have.property("id", expectedID);
+});
+
+// TODO (Best Practice): lastUserId is assigned here but never read — the downstream Then step
+// receives userId directly as a Cucumber parameter. This variable is dead code and can be removed.
+let lastUserId: number;
+
+When("I fetch all posts for userId {int}", (userId: number) => {
+  lastUserId = userId;
+  PostService.getPostsByUserId(userId).then((response) => {
+    lastResponse = response;
+  });
+});
+
+Then("I should receive {int} posts", (expectedCount: number) => {
+  expect(lastResponse.status).to.eq(200);
+  expect(lastResponse.body).to.be.an("array").with.lengthOf(expectedCount);
+});
+
+Then("every post should belong to userId {int}", (userId: number) => {
+  lastResponse.body.forEach((post: { userId: number }) => {
+    expect(post.userId).to.eq(userId);
+  });
 });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -1,10 +1,5 @@
-import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import { When, Then, Before } from "@badeball/cypress-cucumber-preprocessor";
 import PostService from "../services/PostService";
-
-// TODO (Best Practice): Storing response in a module-level variable shares state across scenarios.
-// Consider using a Cypress alias instead (e.g. cy.wrap(response).as('lastResponse') and cy.get('@lastResponse'))
-// so that response state is naturally scoped to each individual scenario.
-let lastResponse: Cypress.Response<any>;
 
 interface NewPost {
   title: string;
@@ -12,48 +7,94 @@ interface NewPost {
   userId: number;
 }
 
-interface PostsData {
-  newPost: NewPost;
+interface ReplacePost {
+  postId: number;
+  title: string;
+  body: string;
+  userId: number;
 }
 
-let postsData: PostsData;
+interface PostsData {
+  newPost: NewPost;
+  replacePost: ReplacePost;
+}
 
-before(() => {
-  cy.fixture("posts.json").then((data) => {
-    postsData = data;
-  });
+Before(() => {
+  cy.fixture("posts.json").as("postsData");
 });
 
 When("I create a new post", () => {
-  const { newPost } = postsData;
-  PostService.createPost(newPost.title, newPost.body, newPost.userId).then(
-    (response) => {
-      lastResponse = response;
-    },
-  );
+  cy.get("@postsData").then((postsData: any) => {
+    const { newPost } = postsData as PostsData;
+    PostService.createPost(newPost.title, newPost.body, newPost.userId).then(
+      (response) => {
+        cy.wrap(response).as("lastResponse");
+      },
+    );
+  });
 });
 
 Then("the response status should be {int}", (statusCode: number) => {
-  expect(lastResponse.status).to.eq(statusCode);
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    expect(lastResponse.status).to.eq(statusCode);
+  });
 });
 
 Then("the ID in the response should be {int}", (expectedID: number) => {
-  expect(lastResponse.body).to.have.property("id", expectedID);
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    expect(lastResponse.body.id).to.eq(expectedID);
+  });
 });
 
 When("I fetch all posts for userId {int}", (userId: number) => {
   PostService.getPostsByUserId(userId).then((response) => {
-    lastResponse = response;
+    cy.wrap(response).as("lastResponse");
   });
 });
 
 Then("I should receive {int} posts", (expectedCount: number) => {
-  expect(lastResponse.status).to.eq(200);
-  expect(lastResponse.body).to.be.an("array").with.lengthOf(expectedCount);
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    expect(lastResponse.status).to.eq(200);
+    expect(lastResponse.body).to.be.an("array").with.lengthOf(expectedCount);
+  });
 });
 
 Then("every post should belong to userId {int}", (userId: number) => {
-  lastResponse.body.forEach((post: { userId: number }) => {
-    expect(post.userId).to.eq(userId);
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    lastResponse.body.forEach((post: { userId: number }) => {
+      expect(post.userId).to.eq(userId);
+    });
+  });
+});
+
+When("I replace the target post with replacement data", function () {
+  cy.get("@postsData").then((postsData: any) => {
+    const { replacePost } = postsData as PostsData;
+    PostService.replacePost(
+      replacePost.postId,
+      replacePost.title,
+      replacePost.body,
+      replacePost.userId,
+    ).then((response) => {
+      cy.wrap(response).as("lastResponse");
+    });
+  });
+});
+
+Then("the post title should match the replacement data", function () {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { replacePost } = postsData as PostsData;
+      expect(lastResponse.body).to.have.property("title", replacePost.title);
+    });
+  });
+});
+
+Then("the post body should match the replacement data", function () {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { replacePost } = postsData as PostsData;
+      expect(lastResponse.body).to.have.property("body", replacePost.body);
+    });
   });
 });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -9,6 +9,7 @@ let lastResponse: Cypress.Response<any>;
 interface NewPost {
   title: string;
   body: string;
+  userId: number;
 }
 
 interface PostsData {
@@ -25,9 +26,11 @@ before(() => {
 
 When("I create a new post", () => {
   const { newPost } = postsData;
-  PostService.createPost(newPost.title, newPost.body).then((response) => {
-    lastResponse = response;
-  });
+  PostService.createPost(newPost.title, newPost.body, newPost.userId).then(
+    (response) => {
+      lastResponse = response;
+    },
+  );
 });
 
 Then("the response status should be {int}", (statusCode: number) => {

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -1,0 +1,32 @@
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import PostService from "../services/PostService";
+
+let lastResponse: Cypress.Response<any>;
+
+interface NewPost {
+  title: string;
+  body: string;
+}
+
+interface PostsData {
+  newPost: NewPost;
+}
+
+let postsData: PostsData;
+
+before(() => {
+  cy.fixture("posts.json").then((data) => {
+    postsData = data;
+  });
+});
+
+When("I create a new post", () => {
+  const { newPost } = postsData;
+  PostService.createPost(newPost.title, newPost.body).then((response) => {
+    lastResponse = response;
+  });
+});
+
+Then("the response status should be {int}", (statusCode: number) => {
+  expect(lastResponse.status).to.eq(statusCode);
+});

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -47,8 +47,10 @@ Before(() => {
 
 Given("the test post is available", () => {
   cy.get<PostsData>("@postsData").then((postsData) => {
-    const { testPostId } = postsData;
-    expect(testPostId).to.exist;
+    PostService.getPostById(postsData.testPostId).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body.id).to.eq(postsData.testPostId);
+    });
   });
 });
 

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -28,6 +28,7 @@ interface ExpectedPost {
 interface PostsData {
   testPostId: number;
   targetUserId: number;
+  allPostsExpectedCount: number;
   allPostsExpectedTotalCount: number;
   expectedPost: ExpectedPost;
   newPost: NewPost;
@@ -131,6 +132,43 @@ Then("every post should belong to the target user", () => {
       const { targetUserId } = postsData as PostsData;
       lastResponse.body.forEach((post: { userId: number }) => {
         expect(post.userId).to.eq(targetUserId);
+      });
+    });
+  });
+});
+
+When("I fetch the target post with embedded comments", () => {
+  cy.get("@postsData").then((postsData: any) => {
+    const { testPostId } = postsData as PostsData;
+    PostService.getCommentsByPostId(testPostId).then((response) => {
+      cy.wrap(response).as("lastResponse");
+    });
+  });
+});
+
+Then(
+  "every item in the response should have a post ID matching the one specified",
+  () => {
+    cy.get("@lastResponse").then((lastResponse: any) => {
+      cy.get("@postsData").then((postsData: any) => {
+        const { testPostId } = postsData as PostsData;
+        expect(lastResponse.body).to.be.an("array").with.length.greaterThan(0);
+        lastResponse.body.forEach((comment: { postId: number }) => {
+          expect(comment.postId).to.eq(testPostId);
+        });
+      });
+    });
+  },
+);
+
+Then("every item in the response should have a name and email", () => {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { testPostId } = postsData as PostsData;
+      expect(lastResponse.body).to.be.an("array").with.length.greaterThan(0);
+      lastResponse.body.forEach((comment: { name: string; email: string }) => {
+        expect(comment).to.have.property("name");
+        expect(comment).to.have.property("email");
       });
     });
   });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -8,19 +8,28 @@ interface NewPost {
 }
 
 interface ReplacePost {
-  postId: number;
   title: string;
   body: string;
   userId: number;
 }
 
 interface PatchPost {
-  postId: number;
   title: string;
   body: string;
 }
 
+interface ExpectedPost {
+  id: number;
+  title: string;
+  body: string;
+  userId: number;
+}
+
 interface PostsData {
+  testPostId: number;
+  targetUserId: number;
+  allPostsExpectedCount: number;
+  expectedPost: ExpectedPost;
   newPost: NewPost;
   replacePost: ReplacePost;
   patchPost: PatchPost;
@@ -53,32 +62,65 @@ Then("the ID in the response should be {int}", (expectedID: number) => {
   });
 });
 
-When("I fetch all posts for userId {int}", (userId: number) => {
-  PostService.getPostsByUserId(userId).then((response) => {
-    cy.wrap(response).as("lastResponse");
-  });
-});
-
-Then("I should receive {int} posts", (expectedCount: number) => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    expect(lastResponse.status).to.eq(200);
-    expect(lastResponse.body).to.be.an("array").with.lengthOf(expectedCount);
-  });
-});
-
-Then("every post should belong to userId {int}", (userId: number) => {
-  cy.get("@lastResponse").then((lastResponse: any) => {
-    lastResponse.body.forEach((post: { userId: number }) => {
-      expect(post.userId).to.eq(userId);
+When("I fetch the target post", () => {
+  cy.get("@postsData").then((postsData: any) => {
+    const { testPostId } = postsData as PostsData;
+    PostService.getPostById(testPostId).then((response) => {
+      cy.wrap(response).as("lastResponse");
     });
   });
 });
 
-When("I replace the target post with replacement data", function () {
+Then("the response should match the expected post data", () => {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { expectedPost } = postsData as PostsData;
+      expect(lastResponse.body).to.deep.include({
+        title: expectedPost.title,
+        body: expectedPost.body,
+        userId: expectedPost.userId,
+      });
+    });
+  });
+});
+
+When("I fetch all posts for the target user", () => {
   cy.get("@postsData").then((postsData: any) => {
-    const { replacePost } = postsData as PostsData;
+    const { targetUserId } = postsData as PostsData;
+    PostService.getPostsByUserId(targetUserId).then((response) => {
+      cy.wrap(response).as("lastResponse");
+    });
+  });
+});
+
+Then("I should receive the expected number of posts", () => {
+  cy.get("@lastResponse").then((lastResponse: any) => {
+    cy.get("@postsData").then((postsData: any) => {
+      const { allPostsExpectedCount } = postsData as PostsData;
+      expect(lastResponse.status).to.eq(200);
+      expect(lastResponse.body)
+        .to.be.an("array")
+        .with.lengthOf(allPostsExpectedCount);
+    });
+  });
+});
+
+Then("every post should belong to the target user", () => {
+  cy.get("@postsData").then((postsData: any) => {
+    cy.get("@lastResponse").then((lastResponse: any) => {
+      const { targetUserId } = postsData as PostsData;
+      lastResponse.body.forEach((post: { userId: number }) => {
+        expect(post.userId).to.eq(targetUserId);
+      });
+    });
+  });
+});
+
+When("I replace the test post with replacement data", function () {
+  cy.get("@postsData").then((postsData: any) => {
+    const { testPostId, replacePost } = postsData as PostsData;
     PostService.replacePost(
-      replacePost.postId,
+      testPostId,
       replacePost.title,
       replacePost.body,
       replacePost.userId,
@@ -106,14 +148,12 @@ Then("the post body should match the replacement data", function () {
   });
 });
 
-When("I update only the title of the target post", function () {
+When("I update the test post with patched data", function () {
   cy.get("@postsData").then((postsData: any) => {
-    const { patchPost } = postsData as PostsData;
-    PostService.patchPost(patchPost.postId, patchPost.title).then(
-      (response) => {
-        cy.wrap(response).as("lastResponse");
-      },
-    );
+    const { testPostId, patchPost } = postsData as PostsData;
+    PostService.patchPost(testPostId, patchPost.title).then((response) => {
+      cy.wrap(response).as("lastResponse");
+    });
   });
 });
 
@@ -131,6 +171,15 @@ Then("the original body should still be present in the response", function () {
     cy.get("@postsData").then((postsData: any) => {
       const { patchPost } = postsData as PostsData;
       expect(lastResponse.body).to.have.property("body", patchPost.body);
+    });
+  });
+});
+
+When("I delete the test post", function () {
+  cy.get("@postsData").then((postsData: any) => {
+    const { testPostId } = postsData as PostsData;
+    PostService.deletePost(testPostId).then((response) => {
+      cy.wrap(response).as("lastResponse");
     });
   });
 });

--- a/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
+++ b/cypress/e2e/jsonplaceholder/step_definitions/post.steps.ts
@@ -41,12 +41,7 @@ Then("the ID in the response should be {int}", (expectedID: number) => {
   expect(lastResponse.body).to.have.property("id", expectedID);
 });
 
-// TODO (Best Practice): lastUserId is assigned here but never read — the downstream Then step
-// receives userId directly as a Cucumber parameter. This variable is dead code and can be removed.
-let lastUserId: number;
-
 When("I fetch all posts for userId {int}", (userId: number) => {
-  lastUserId = userId;
   PostService.getPostsByUserId(userId).then((response) => {
     lastResponse = response;
   });

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -1,21 +1,25 @@
 {
+  "testPostId": 1,
+  "targetUserId": 1,
+  "allPostsExpectedCount": 10,
+  "expectedPost": {
+    "id": 1,
+    "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+    "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto",
+    "userId": 1
+  },
   "newPost": {
     "title": "Cypress API Testing",
     "body": "Learning Focus 3",
     "userId": 1
   },
   "replacePost": {
-    "postId": 1,
     "title": "Updating a Post",
     "body": "This replaces all",
     "userId": 5
   },
   "patchPost": {
-    "postId": 1,
     "title": "Patched Title",
     "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
-  },
-  "deletePost": {
-    "postId": 1
   }
 }

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -1,0 +1,23 @@
+{
+  "newPost": {
+    "title": "Cypress API Testing",
+    "body": "Learning Focus 3"
+  },
+  "filteredPosts": {
+    "userId": 1,
+    "postCount": 10
+  },
+  "replacedPost": {
+    "postId": 1,
+    "title": "Brand New Post",
+    "body": "This replaces all",
+    "userId": 5
+  },
+  "patchedPost": {
+    "postId": 1,
+    "title": "Patched Title"
+  },
+  "deletedPost": {
+    "postId": 1
+  }
+}

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -3,21 +3,17 @@
     "title": "Cypress API Testing",
     "body": "Learning Focus 3"
   },
-  "filteredPosts": {
-    "userId": 1,
-    "postCount": 10
-  },
-  "replacedPost": {
+  "replacePost": {
     "postId": 1,
     "title": "Brand New Post",
     "body": "This replaces all",
     "userId": 5
   },
-  "patchedPost": {
+  "patchPost": {
     "postId": 1,
     "title": "Patched Title"
   },
-  "deletedPost": {
+  "deletePost": {
     "postId": 1
   }
 }

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -12,7 +12,8 @@
   },
   "patchPost": {
     "postId": 1,
-    "title": "Patched Title"
+    "title": "Patched Title",
+    "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
   },
   "deletePost": {
     "postId": 1

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -2,6 +2,7 @@
   "testPostId": 1,
   "targetUserId": 1,
   "allPostsExpectedCount": 10,
+  "allPostsExpectedTotalCount": 100,
   "expectedPost": {
     "id": 1,
     "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -6,7 +6,7 @@
   },
   "replacePost": {
     "postId": 1,
-    "title": "Brand New Post",
+    "title": "Updating a Post",
     "body": "This replaces all",
     "userId": 5
   },

--- a/cypress/fixtures/posts.json
+++ b/cypress/fixtures/posts.json
@@ -1,7 +1,8 @@
 {
   "newPost": {
     "title": "Cypress API Testing",
-    "body": "Learning Focus 3"
+    "body": "Learning Focus 3",
+    "userId": 1
   },
   "replacePost": {
     "postId": 1,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true,
-    "stepDefinitions": "cypress/e2e/saucedemo/step_definitions/**/*.{js,ts}"
+    "stepDefinitions": [
+      "cypress/e2e/saucedemo/step_definitions/**/*.{js,ts}",
+      "cypress/e2e/jsonplaceholder/step_definitions/**/*.{js,ts}"
+    ]
   }
 }


### PR DESCRIPTION
This PR extends the existing Focus 2 Cypress repo with a solution to the Focus 3 brief (attached below.)

[Focus 3 Resources.md](https://github.com/user-attachments/files/28398506/Focus.3.Resources.md)

We employ the existing Page Object Model and use of fixtures from Focus 2, adapted for the [jsonplaceholder](https://jsonplaceholder.typicode.com/) API. 

Coverage of each operation documented in the JSONPlaceholder guide [https://jsonplaceholder.typicode.com/guide/](url) is provided.

We add new feature files, step definitions, supporting services, and test data fixtures, and update configuration files to support the new tests.

**API Testing for JSONPlaceholder `/posts`:**

* Added a new feature file `posts.feature` that defines end-to-end scenarios for creating, reading, updating, and deleting posts, including nested resource and filter tests.
* Implemented step definitions in `post.steps.ts` to automate the scenarios using Cypress and the Cucumber preprocessor, leveraging test data from a new fixture.
* Introduced `PostService.ts`, encapsulating all API interactions for the `/posts` resource, following the Page Object Model pattern.
* Added a fixture file `posts.json` containing reusable test data for the scenarios.

**Configuration and Environment Updates:**

* Updated Cypress and Cucumber configuration in `cypress.config.ts`, `package.json`, `.vscode/settings.json`, and `.vscode/extensions.json` to include the new step definitions and recommend the Cucumber extension.
* Updated `cypress.env.json` to include a real API base URL and improved placeholder credentials.